### PR TITLE
Updated the tools to use SKU fields instead of storing a GUID in metafields

### DIFF
--- a/distro/bin/weirdcanada-distro.bat
+++ b/distro/bin/weirdcanada-distro.bat
@@ -1,0 +1,3 @@
+@Echo Off
+java -server -Xmx800m -XX:MaxPermSize=200m -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSIncrementalPacing -XX:ParallelGCThreads=2 -jar jars\weirdcanada-distro.jar -Drun.mode=test
+

--- a/distro/src/main/scala/org/weirdcanada/distro/api/shopify/Shopify.scala
+++ b/distro/src/main/scala/org/weirdcanada/distro/api/shopify/Shopify.scala
@@ -178,13 +178,6 @@ class Shopify(config: Config) extends Loggable {
     }
   }
 
-  def addProductVariant(productId: Long, metafields: Seq[Metafield], variantOptions: Map[Int,String], options: (String, Any)*): PersistentVariant = {
-    post("/admin/products/%s/variants.json".format(productId), Variant.ByMetafields(metafields, variantOptions)) match {
-      case Variant(result) => result
-      case _ => sys.error("Failed to add product %s variant: %s".format(productId, metafields.toString))
-    }
-  }
-
   
   private val metafieldOptions: (String, Any) =
     "fields" -> "created_at,id,key,value,value_type,namespace"

--- a/distro/src/main/scala/org/weirdcanada/distro/data/Album.scala
+++ b/distro/src/main/scala/org/weirdcanada/distro/data/Album.scala
@@ -22,6 +22,7 @@ class Album extends LongKeyedMapper[Album] with IdPK with ManyToMany with OneToM
   object description extends MappedText(this)
   object sku extends MappedString(this, 32)
   object shopifyId extends MappedLong(this)
+  object barcode extends MappedString(this, 32) // UPC, ISBN, etc
 
   object format extends MappedEnum(this, Album.Type)
   object isFirstPressing extends MappedBoolean(this)
@@ -62,6 +63,25 @@ class Album extends LongKeyedMapper[Album] with IdPK with ManyToMany with OneToM
       "lathe"
     else 
       "cool"
+  }
+
+  /**
+   * Convert the `Type` enum to a char (for use in the SKU)
+   *
+   * @returns a char representation of the enum
+   */
+  def formatTypeChar: Char = {
+    import Album.Type._
+    format.is match {
+      case CompactDisc     => 'C'
+      case Vinyl           => 'V'
+      case TwelveInchVinyl => 'F' // Foot
+      case SevenInchVinyl  => '7'
+      case Cassette        => 'T' // Tape
+      case Digital         => 'D'
+      case Lathe           => 'L'
+      case _               => 'X'
+    }
   }
 
   /**

--- a/distro/src/main/scala/org/weirdcanada/distro/page/ConsignorPage.scala
+++ b/distro/src/main/scala/org/weirdcanada/distro/page/ConsignorPage.scala
@@ -283,7 +283,7 @@ class ConsignorPage(service: Service) extends DispatchSnippet {
             "@sold" #> 1 &
             "@remaining" #> 2 &
             "@price" #> "%s // %s".format(consignedItem.customerCost.is, consignedItem.wholesaleCost.is) &
-            "@sku" #> consignedItem.guid &
+            "@sku" #> consignedItem.sku &
             "@image [src]" #> album.imageUrl &
             "@artist" #> album.artists.map { _.name.is }.mkString { " // " } &
             "@title" #> album.title.is &


### PR DESCRIPTION
Default SKU format is currently WC-X-######, where X is a single character representing the format and the number is a 6-digit number equivalent to 54040 + ConsignedItem.id

I've also added a field for barcode, but haven't done anything with it. It's up to you whether you want to hook up the UPC/ISBN of a physical product to this field. (There's a spot for it in Shopify... so it might be good to track it)
